### PR TITLE
Feature/yomin

### DIFF
--- a/mpmt/modules/http/HttpResponseInfo.cpp
+++ b/mpmt/modules/http/HttpResponseInfo.cpp
@@ -38,7 +38,7 @@ void Response::setStatusCode(int statusCode) {
 
 void Response::setHeaders(std::string httpV) {
 	this->_headers = httpV + " " + toString(this->_statusCode) + " " + this->_statusMsg + "\r\n" + "Content-Type: " + "text/html" + "\r\n";
-	if (this->_statusCode == 301 || this->_statusCode == 302)
+	if ((this->_statusCode == 301 && this->_location != "") || (this->_statusCode == 302 && this->_location != ""))
 		this->_headers += "Location: " + this->_location + "\r\n";
 	this->_body != "" ? this->_headers += "Content-Length: " + toString(this->_body.length()) + "\r\n\r\n" : this->_headers += "\r\n\r\n";
 }	

--- a/mpmt/modules/http/HttpResponseInfo.cpp
+++ b/mpmt/modules/http/HttpResponseInfo.cpp
@@ -1,4 +1,5 @@
 #include "HttpResponseInfo.hpp"
+#include <algorithm>
 
 Response::Response(){};
 
@@ -12,7 +13,19 @@ Response& Response::operator=(const Response &rhs) {
 	this->setStatusMsg(rhs.getStatusCode());
     return (*this);
 }
-	
+
+std::string toString(int n) {
+	std::string tmp;
+
+	while (n > 0) {
+		tmp.push_back(n%10 + '0');
+		n /= 10;
+	}
+	reverse(tmp.begin(), tmp.end());
+	return (tmp); 
+}
+
+
 void Response::setStatusMsg(int statusCode) {
 	http_status_msg msg = http_status_msg(statusCode);
 	this->_statusMsg = msg.getStatusMsg();
@@ -24,22 +37,26 @@ void Response::setStatusCode(int statusCode) {
 //객체를 받아서 스트림 그자체로 쓸 수도 있음.
 
 void Response::setHeaders(std::string httpV) {
-	this->_headers << httpV << " " << this->_statusCode << " " << this->_statusMsg << "\r\n";
-	this->_headers << "Content-Type: " << "text/html" << "\r\n";
+	this->_headers = httpV + " " + toString(this->_statusCode) + " " + this->_statusMsg + "\r\n" + "Content-Type: " + "text/html" + "\r\n";
 	if (this->_statusCode == 301 || this->_statusCode == 302)
-		this->_headers << "Location: " << "probly file Path Variable added" << "\r\n";
-	this->_body.str() != "" ? this->_headers << "Content-Length: " << this->_body.str().length() << "\r\n\r\n" : this->_headers << "\r\n\r\n";
+		this->_headers += "Location: " + this->_location + "\r\n";
+	this->_body != "" ? this->_headers += "Content-Length: " + toString(this->_body.length()) + "\r\n\r\n" : this->_headers += "\r\n\r\n";
 }	
+void Response::setLocation(std::string location) {
+	this->_body = location;
+};
+
 void Response::setBody(std::string body) {
-	this->_body << body;
+	this->_body = body;
 }
 
 void Response::setBuf(){
-	this->_buf << getHeader() << getBody();
+	this->_buf += getHeader();
+	this->_buf += getBody();
 }
 
-std::string Response::getBody() const { return this->_body.str();};
-std::string Response::getHeader() const { return this->_headers.str();};
-std::string Response::getBuf() const {return this->_buf.str(); };
-std::string Response::getStatusMsg() const { return this->_statusMsg; };
+std::string& Response::getBody(){ return this->_body;};
+std::string& Response::getHeader() { return this->_headers;};
+std::string& Response::getBuf() {return this->_buf; };
+std::string& Response::getStatusMsg() { return this->_statusMsg; };
 int Response::getStatusCode() const { return this->_statusCode; };

--- a/mpmt/modules/http/HttpResponseInfo.hpp
+++ b/mpmt/modules/http/HttpResponseInfo.hpp
@@ -4,6 +4,8 @@
 
 # include <iostream>
 # include <sstream>
+# include <cstdlib>
+
 # include "commonHttpInfo.hpp"
 #define HTTPV10 "HTTP/1.0" // HTTP/1.0
 #define HTTPV11 "HTTP/1.1" // HTTP/1.1
@@ -24,22 +26,24 @@ class Response {
 
 		void setHeaders(std::string httpV);	
 		void setBody(std::string body);
+		void setLocation(std::string location);
 		void setBuf();
 
-		std::string getBody() const;
-		std::string getHeader() const;
-		std::string getBuf() const;
+		std::string& getBody();
+		std::string& getHeader();
+		std::string& getBuf();
 
-		std::string getStatusMsg() const;
+		std::string& getStatusMsg();
 		int getStatusCode() const;
 		
 	//destoryer
 	protected:
 		int _statusCode;
 		std::string _statusMsg;
-		std::stringstream _headers;
-		std::stringstream _body;
-		std::ostringstream _buf;
+		std::string _location;
+		std::string _headers;
+		std::string _body;
+		std::string _buf;
 };
 
 #endif

--- a/mpmt/modules/http/responseHandler.cpp
+++ b/mpmt/modules/http/responseHandler.cpp
@@ -25,6 +25,9 @@ void responseHandler::setResBody(std::string body) const {
 	this->_res->setBody(body); 
 };
 
+void responseHandler::setResLocation(std::string location) const { 
+	this->_res->setLocation(location); 
+};
 void responseHandler::setResHeader(std::string HttpV) const { 
 	this->_res->setHeaders(HttpV); 
 };
@@ -49,7 +52,12 @@ void *responseHandler::handle(void *event) {
 	Event *e = static_cast<Event *>(event);
 
 	this->setRes(302);
-	this->setResBody("bodybody");
+	//change a value below,
+	//if (e->something->content for responseBody)
+	//	this->setResBody(e->something->content);
+	//if (e->something->redirectLocation)
+	//	this->setResLocation(e->something->redirectLoaction);
+
 	std::cout << "=====================\n" << this->getResBody() << "=====================\n" << std::endl;
 	this->setResHeader(HTTPV11);
 	std::cout << "=====================\n" << this->getResHeader() << "=====================\n" << std::endl;

--- a/mpmt/modules/http/responseHandler.cpp
+++ b/mpmt/modules/http/responseHandler.cpp
@@ -33,15 +33,15 @@ void responseHandler::setResBuf() const {
 	this->_res->setBuf(); 
 };
 
-std::string responseHandler::getResBody() const {
+std::string& responseHandler::getResBody() const {
 	return this->_res->getBody();
 };
 
-std::string responseHandler::getResHeader() const {
+std::string& responseHandler::getResHeader() const {
 	return this->_res->getHeader();
 };
 
-std::string responseHandler::getResBuf() const {
+std::string& responseHandler::getResBuf() const {
 	return this->_res->getBuf();
 };
 

--- a/mpmt/modules/http/responseHandler.hpp
+++ b/mpmt/modules/http/responseHandler.hpp
@@ -18,9 +18,9 @@ public:
 	void setResBody(std::string body) const;
 	void setResHeader(std::string HttpV) const;
 	void setResBuf() const;
-	std::string getResBody() const;
-	std::string getResHeader() const;
-	std::string getResBuf() const;
+	std::string& getResBody() const;
+	std::string& getResHeader() const;
+	std::string& getResBuf() const;
 	void *handle(void *event);
 private:
 	responseHandler& operator=(const responseHandler &rhs);


### PR DESCRIPTION
old ver: Response Obj has StringStream(headers, body) and ostringstream(buf).
but it was slower than using std::string when convert a type.

new ver: Response Obj has string(headers, body, location, buf)
because of need a function for convert int to string, then add function toString().
and also add a location var when using redirect status code to header string.
last, check a statement body and location var that event obj has after would be filling.
