### PR TITLE
fix about content-length

### DIFF
--- a/mpmt/modules/http/HttpResponseInfo.cpp
+++ b/mpmt/modules/http/HttpResponseInfo.cpp
@@ -40,7 +40,8 @@ void Response::setHeaders(std::string httpV) {
 	this->_headers = httpV + " " + toString(this->_statusCode) + " " + this->_statusMsg + "\r\n" + "Content-Type: " + "text/html" + "\r\n";
 	if ((this->_statusCode == 301 && this->_location != "") || (this->_statusCode == 302 && this->_location != ""))
 		this->_headers += "Location: " + this->_location + "\r\n";
-	this->_body != "" ? this->_headers += "Content-Length: " + toString(this->_body.size()) + "\r\n\r\n" : this->_headers += "\r\n\r\n";
+	this->_headers += "Content-Length: ";
+	this->_body != "" ? this->_headers += toString(this->_body.size()) + "\r\n\r\n" : this->_headers += "0\r\n\r\n";
 }	
 void Response::setLocation(std::string location) {
 	this->_location = location;

--- a/mpmt/modules/http/testRes.cpp
+++ b/mpmt/modules/http/testRes.cpp
@@ -21,13 +21,14 @@ int main(void)
 		test.seekg(0, std::ios::end);
 		test.read(&s[0], size);
 	}
-	int i = 0;
+	/* int i = 0;
 	std::cout<< s << std::endl;
 	while (i < 3) {
 		Res->setResBody(s);
 		Res->setResBody("======================================\n");
 		i++;
-	}
+	} */
+	Res->setResBody("");
 	Res->setResStatusCode(301);
 	Res->setResStatusMsg(301);
 


### PR DESCRIPTION
old ver: add contentLength only _res body exist

new ver: alway add contentLength even if _res body does not exist.
_res->body ? add body size : "0"