### PR TITLE
add function for cookie string set

### DIFF
--- a/mpmt/modules/eventLoop/Event.hpp
+++ b/mpmt/modules/eventLoop/Event.hpp
@@ -135,7 +135,7 @@ public:
 	struct stat statBuf;
 	int fileReadByte;
 	int fileWroteByte;
-
+	unsigned int sid;
 
 public:
 	void (*callback)(struct kevent *e, Event* ev);

--- a/mpmt/modules/eventLoop/registerEvent.cpp
+++ b/mpmt/modules/eventLoop/registerEvent.cpp
@@ -43,6 +43,12 @@ void EventLoop::registerClientSocketWriteEvent(Event *e)
 		e->setStatusCode(e->internal_status);
 
 	e->setEventType(E_CLIENT_SOCKET);
+
+	if (!static_cast<HttpreqHandler *>(e->getRequestHandler())->getHasSid())
+	{
+		HttpServer::getInstance().issueSessionId();
+	}
+
 	/**
 	 * 최종적으로 client socket에 write하기전에 한 번만 호출되는 곳이므로, 여기서 response message와 wrotebyte를 설정해야함.
 	 * */

--- a/mpmt/modules/http/HttpResponseInfo.cpp
+++ b/mpmt/modules/http/HttpResponseInfo.cpp
@@ -14,7 +14,7 @@ Response& Response::operator=(const Response &rhs) {
     return (*this);
 }
 
-std::string toString(int n) {
+std::string toString(size_t n) {
 	std::string tmp;
 
 	while (n > 0) {
@@ -24,6 +24,7 @@ std::string toString(int n) {
 	reverse(tmp.begin(), tmp.end());
 	return (tmp); 
 }
+
 void Response::setCgiBody(std::string const &substr) {
 	this->_body.erase();
 	this->_body += substr; 
@@ -36,6 +37,10 @@ void Response::setStatusMsg(int statusCode) {
 
 void Response::setStatusCode(int statusCode) {
 	this->_statusCode = statusCode;
+}
+
+void Response::setCookie(std::string const &cookie) {
+	this->_cookie += cookie;
 }
 //객체를 받아서 스트림 그자체로 쓸 수도 있음.
 
@@ -56,6 +61,8 @@ void Response::setHeaders(std::string const &httpV) {
 
 	if ((this->_statusCode == 301 && this->_location != "") || (this->_statusCode == 302 && this->_location != ""))
 		this->_headers += "Location: " + this->_location + "\r\n";
+	if (this->getCookie().find("Set-Cookie") != std::string::npos)
+		this->_headers += this->getCookie();
 	this->_headers += "Content-Length: ";
 
 	/* this->_body != "" ? this->_headers += toString(this->_body.size()) + "\r\n\r\n" : this->_headers += "0\r\n\r\n"; */
@@ -82,4 +89,5 @@ std::string& Response::getBody(){ return this->_body;};
 std::string& Response::getHeader() { return this->_headers;};
 std::string& Response::getBuf() {return this->_buf; };
 std::string& Response::getStatusMsg() { return this->_statusMsg; };
+std::string& Response::getCookie() { return this->_cookie; };
 int Response::getStatusCode() const { return this->_statusCode; };

--- a/mpmt/modules/http/HttpResponseInfo.hpp
+++ b/mpmt/modules/http/HttpResponseInfo.hpp
@@ -28,25 +28,29 @@ class Response {
 		void setBody(std::string const &body);
 		void setLocation(std::string const &location);
 		void setCgiBody(std::string const &substr);
+		void setCookie(std::string const &cookie);
 		void setBuf();
 
 		std::string& getBody();
 		std::string& getHeader();
 		std::string& getBuf();
-
+		std::string& getCookie();
 		std::string& getStatusMsg();
 		int getStatusCode() const;
 		
 	//destoryer
 	protected:
 		int _statusCode;
-		int _sid;
 		
 		std::string _statusMsg;
 		std::string _location;
 		std::string _headers;
 		std::string _body;
 		std::string _buf;
+		std::string _cookie;
+
 };
+
+std::string toString(size_t n);
 
 #endif

--- a/mpmt/modules/http/HttpResponseInfo.hpp
+++ b/mpmt/modules/http/HttpResponseInfo.hpp
@@ -40,6 +40,8 @@ class Response {
 	//destoryer
 	protected:
 		int _statusCode;
+		int _sid;
+		
 		std::string _statusMsg;
 		std::string _location;
 		std::string _headers;

--- a/mpmt/modules/http/HttpServer.cpp
+++ b/mpmt/modules/http/HttpServer.cpp
@@ -1,5 +1,13 @@
 #include "HttpServer.hpp"
 
+unsigned int hash(unsigned int x) 
+{
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = (x >> 16) ^ x;
+    return x;
+}
+
 HttpServer& HttpServer::getInstance()
 {
 	static HttpServer instance;
@@ -23,6 +31,10 @@ void HttpServer::init() throw(std::runtime_error)
 
 std::vector<struct kevent> & HttpServer::getKevents() { return this->kevents; }
 
+unsigned int HttpServer::issueSessionId()
+{
+	return hash(static_cast<unsigned int>(time(NULL)));
+}
 
 char* HttpServer::getHttpBuffer() { return this->HttpBuffer; }
 

--- a/mpmt/modules/http/HttpServer.hpp
+++ b/mpmt/modules/http/HttpServer.hpp
@@ -29,6 +29,10 @@ private:
 	 */
 	std::vector<struct kevent> kevents;
 
+	/**
+	 * session
+	 * */
+	std::map<int, int> _session;
 
 	//1024로 설정. 나중에 수정 필요
 	//nginx의 client_body_buffer_size, client_header_buffer_size 확인할 것.
@@ -60,6 +64,10 @@ public:
    * @return char * of http buffer
    */
   char* getHttpBuffer();
+
+  /**
+   * */
+  unsigned int issueSessionId();
 
 private:
   HttpServer(); 

--- a/mpmt/modules/http/responseHandler.cpp
+++ b/mpmt/modules/http/responseHandler.cpp
@@ -1,6 +1,6 @@
 #include "responseHandler.hpp"
 #include "HttpreqHandler.hpp"
-
+#include "HttpServer.hpp"
 
 
 responseHandler::responseHandler() {
@@ -40,10 +40,24 @@ void responseHandler::setResLocation(std::string location) const {
 	this->_res->setLocation(location); 
 };
 
+void responseHandler::setResCookie(std::string cookieString) const {
+	this->_res->setCookie(cookieString);
+};
+
 void responseHandler::setResAddtionalOptions(Event *event) const {
 	std::string httpMethod = static_cast<HttpreqHandler *>(event->getRequestHandler())->getRequestInfo().method;
 	std::string requestedResource = static_cast<HttpreqHandler *>(event->getRequestHandler())->getRequestInfo().path;
 	int statusCode = this->getResStatusCode();
+	
+	std::cout << "================================" << static_cast<HttpreqHandler *>(event->getRequestHandler())->getHasSid() << "========================" << std::endl;
+	if (static_cast<HttpreqHandler *>(event->getRequestHandler())->getHasSid())
+	{
+		std::string cookieString = static_cast<HttpreqHandler *>(event->getRequestHandler())->getRequestInfo().reqHeaderMap.find("Cookie")->second;
+		this->setResCookie("Cookie: " + cookieString + "\r\n");
+	} else {
+		unsigned int tmpId = HttpServer::getInstance().issueSessionId();
+		this->setResCookie("Set-Cookie: sid=" + toString(tmpId) +"; max-age:86400;\r\n");
+	}
 
 	if (httpMethod == "GET") {
 		if (statusCode >= 300 && statusCode < 400)

--- a/mpmt/modules/http/responseHandler.hpp
+++ b/mpmt/modules/http/responseHandler.hpp
@@ -21,6 +21,8 @@ public:
 	void setResAddtionalOptions(Event *event) const;
 	void setResStatusCode(const int& statusCode) const;
 	void setResStatusMsg(const int& statusCode) const;
+	void setResCookie(std::string cookieString) const;
+
 	void setResBuf() const;
 	std::string& getResBody() const;
 	std::string& getResHeader() const;


### PR DESCRIPTION
Over all:
add function setCookie & getCookie in Response Obj,
also add setResCookie but does not made a getResCookie because of we don't need a getting cookie string in responseHanlder Yet.

also, add Phrase check Response need add a Set-Cookie in response header or ignore.
but in ignored, response has a cookie information for Extensibility